### PR TITLE
url of repo added

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python==3.12
+  - python==3.11
   - scipy
   - matplotlib
   - jupyter-book

--- a/epriprog/_config.yml
+++ b/epriprog/_config.yml
@@ -31,3 +31,6 @@ sphinx:
 
 launch_buttons:
   binderhub_url: "https://mybinder.org" 
+
+repository:
+  url: https://github.com/gertingold/epriprog


### PR DESCRIPTION
In addition, the Python version was reverted to 3.11 because binder does not support 3.12 at this point.